### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "CoreCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/PromiseKit" "087b3cf470890ff9ea841212e2f3e285fecf3988"

--- a/PMKSystemConfiguration.xcodeproj/project.pbxproj
+++ b/PMKSystemConfiguration.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6362F84F1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 6362F84D1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m */; };
 		6383E14B1D611E0D00897651 /* SCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383E14A1D611E0D00897651 /* SCTests.swift */; };
 		63C7FFF71D5C020D003BAE60 /* PMKSystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C7FFA71D5BEE09003BAE60 /* PMKSystemConfiguration.framework */; };
+		911E6FC820F578E2006F49B9 /* SCNetworkReachability+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +35,7 @@
 		63C7FFF21D5C020D003BAE60 /* PMKSCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKSCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		63CCF8121D5C0C4E00503216 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		63CCF8171D5C11B500503216 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SCNetworkReachability+Promise.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				6358AB791D5D4B6700B9B157 /* PMKSystemConfiguration.h */,
 				6362F84C1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.h */,
 				6362F84D1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m */,
+				911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -208,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6362F84F1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m in Sources */,
+				911E6FC820F578E2006F49B9 /* SCNetworkReachability+Promise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/SCNetworkReachability+Promise.swift
+++ b/Sources/SCNetworkReachability+Promise.swift
@@ -7,6 +7,8 @@ public extension SCNetworkReachability {
         case couldNotInitializeReachability
     }
 
+    /// - Note: cancelling this promise will cancel the underlying task
+    /// - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     static func promise() -> Promise<Void> {
         do {
             if let promise = try pending()?.promise {
@@ -70,12 +72,3 @@ private class Helper {
         }
     }
 }
-
-//////////////////////////////////////////////////////////// Cancellable wrapper
-
-extension SCNetworkReachability {
-    static func cancellablePromise() -> CancellablePromise<Void> {
-        return cancellable(promise())
-    }
-}
-

--- a/Sources/SCNetworkReachability+Promise.swift
+++ b/Sources/SCNetworkReachability+Promise.swift
@@ -9,22 +9,30 @@ public extension SCNetworkReachability {
 
     static func promise() -> Promise<Void> {
         do {
-            var zeroAddress = sockaddr()
-            zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
-            zeroAddress.sa_family = sa_family_t(AF_INET)
-            guard let ref = SCNetworkReachabilityCreateWithAddress(nil, &zeroAddress) else {
-                throw PMKError.couldNotInitializeReachability
-            }
-
-            var flags = SCNetworkReachabilityFlags()
-            if SCNetworkReachabilityGetFlags(ref, &flags), flags.contains(.reachable) {
+            if let promise = try pending()?.promise {
+                return promise
+            } else {
                 return Promise()
             }
-
-            return try Helper(ref: ref).pending.promise
         } catch {
             return Promise(error: error)
         }
+    }
+    
+    fileprivate static func pending() throws -> (promise: Promise<Void>, resolver: Resolver<Void>)? {
+        var zeroAddress = sockaddr()
+        zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zeroAddress.sa_family = sa_family_t(AF_INET)
+        guard let ref = SCNetworkReachabilityCreateWithAddress(nil, &zeroAddress) else {
+            throw PMKError.couldNotInitializeReachability
+        }
+
+        var flags = SCNetworkReachabilityFlags()
+        if SCNetworkReachabilityGetFlags(ref, &flags), flags.contains(.reachable) {
+            return nil
+        }
+
+        return try Helper(ref: ref).pending
     }
 }
 
@@ -40,6 +48,10 @@ private class Helper {
 
     init(ref: SCNetworkReachability) throws {
         self.ref = ref
+        
+        // Set 'reject' for cancellation so that the promise will be rejected if cancelled.  The 'ensure' block
+        // below will automatically clean up the callback and dispatch queue when the promise is rejected.
+        pending.promise.setCancellableTask(nil, reject: pending.resolver.reject)
 
         var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
         context.info = UnsafeMutableRawPointer(Unmanaged<Helper>.passUnretained(self).toOpaque())
@@ -58,3 +70,12 @@ private class Helper {
         }
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellable wrapper
+
+extension SCNetworkReachability {
+    static func cancellablePromise() -> CancellablePromise<Void> {
+        return cancellable(promise())
+    }
+}
+


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
