### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,3 @@
 github "mxcl/PromiseKit" ~> 6.0
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKSystemConfiguration.xcodeproj/project.pbxproj
+++ b/PMKSystemConfiguration.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 			);
 			inputPaths = (
 				PromiseKit,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/PMKSystemConfiguration.xcodeproj/project.pbxproj
+++ b/PMKSystemConfiguration.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6362F84F1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 6362F84D1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m */; };
 		6383E14B1D611E0D00897651 /* SCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383E14A1D611E0D00897651 /* SCTests.swift */; };
 		63C7FFF71D5C020D003BAE60 /* PMKSystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C7FFA71D5BEE09003BAE60 /* PMKSystemConfiguration.framework */; };
+		911E6FC820F578E2006F49B9 /* SCNetworkReachability+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +35,7 @@
 		63C7FFF21D5C020D003BAE60 /* PMKSCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKSCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		63CCF8121D5C0C4E00503216 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		63CCF8171D5C11B500503216 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SCNetworkReachability+Promise.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				6358AB791D5D4B6700B9B157 /* PMKSystemConfiguration.h */,
 				6362F84C1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.h */,
 				6362F84D1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m */,
+				911E6FC720F578E2006F49B9 /* SCNetworkReachability+Promise.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -208,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6362F84F1D5D934C0021D2DD /* SCNetworkReachability+AnyPromise.m in Sources */,
+				911E6FC820F578E2006F49B9 /* SCNetworkReachability+Promise.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SCTests.swift
+++ b/Tests/SCTests.swift
@@ -1,3 +1,4 @@
+import PMKCancel
 import PMKSystemConfiguration
 import XCTest
 


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
